### PR TITLE
chore: fix build-docker-image workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -12,11 +12,8 @@ on:
         required: true
         default: false
       runs-on:
-        type: choice
+        type: string
         required: true
-        options:
-          - ubuntu-latest
-          - windows-latest
         default: ubuntu-latest
 
 permissions:


### PR DESCRIPTION
Fix input type `runs-on` as choice is supported only on workflow_diwpatch and not workflow_call