### PR TITLE
fix(graalvm): workflow not triggered by push on main

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - 'graalvm-v*'
     paths:


### PR DESCRIPTION
The `graalvm` was triggered on the wrong branch name (master instead of main).